### PR TITLE
Dial back on keyboard shortcut detection

### DIFF
--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -43,7 +43,7 @@ const Keyboard = ({
       if (gameDisabled) return
 
       const letter = event.key.toUpperCase()
-      const areAnyModifiersPressed = event.ctrlKey || event.shiftKey || event.altKey || event.metaKey;
+      const areAnyModifiersPressed = event.ctrlKey || event.altKey || event.metaKey;
 
       if (!areAnyModifiersPressed && letters.includes(letter)) {
         addLetter(letter)

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -43,7 +43,7 @@ const Keyboard = ({
       if (gameDisabled) return
 
       const letter = event.key.toUpperCase()
-      const areAnyModifiersPressed = event.ctrlKey || event.altKey || event.metaKey;
+      const areAnyModifiersPressed = event.ctrlKey || event.altKey || event.metaKey
 
       if (!areAnyModifiersPressed && letters.includes(letter)) {
         addLetter(letter)


### PR DESCRIPTION
Allow the game to consume Shift+letter events because those can't be shortcuts by themselves